### PR TITLE
Improve error handling on agent download

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,7 +89,11 @@ puts_verbose "DT_DOWNLOAD_URL=$DT_DOWNLOAD_URL" | sed "s#$DT_API_TOKEN#DEDUCTED#
 
 # Download and install the agent
 INSTALLER_FILE=$(mktemp)
+# disable errexit temporarily as error handling is done explicitly by downloadAgent
+set +e
 downloadAgent "${DT_DOWNLOAD_URL}" "${INSTALLER_FILE}"
+set -e
+
 puts_step "Running Dynatrace OneAgent installer..."
 sh "${INSTALLER_FILE}" "${BUILD_DIR}"
 


### PR DESCRIPTION
As `errexit` is enabled globally the error handling implemented in
downloadAgent did not have any effect. For improved resilience `errexit` is
disabled for function downloadAgent.