### PR TITLE
Use Python via the `python3` command instead of `python`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,11 +112,11 @@ puts_step "Configuring Dynatrace Oneagent..."
 # determine default values for connection parameters
 DT_MANIFEST="$BUILD_DIR/dynatrace/oneagent/manifest.json"
 
-MANIFEST_TENANT=$(python -c 'import json,sys; print(json.load(sys.stdin)["tenantUUID"])' <$DT_MANIFEST)
-MANIFEST_TOKEN=$(python -c 'import json,sys; print(json.load(sys.stdin)["tenantToken"])' <$DT_MANIFEST)
-MANIFEST_ENDPOINTS=$(python -c 'import sys, json; print(";".join(json.load(sys.stdin)["communicationEndpoints"]))' <$DT_MANIFEST)
+MANIFEST_TENANT=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tenantUUID"])' <$DT_MANIFEST)
+MANIFEST_TOKEN=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tenantToken"])' <$DT_MANIFEST)
+MANIFEST_ENDPOINTS=$(python3 -c 'import sys, json; print(";".join(json.load(sys.stdin)["communicationEndpoints"]))' <$DT_MANIFEST)
 
-VERSION=$(python -c 'import json,sys; print(json.load(sys.stdin)["version"])' <$DT_MANIFEST)
+VERSION=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])' <$DT_MANIFEST)
 
 # support pipelined deployments by overriding default values
 set_env "DT_TENANT" "\${DT_TENANT:-$MANIFEST_TENANT}"


### PR DESCRIPTION
The `python` command was a transitionary symlink to `python3`, that no longer exists on Heroku-24.

To fix compatibility with Heroku-24, the buildpack now calls the `python3` command directly.

Both `python` and `python3` pointed to the same Python installation on all supported Heroku stacks, so this is both supported and a no-op for older stacks.

In addition, the buildpack was already using Python 3 syntax in the commands it called (eg the function form of `print()`), so calling Python via the `python3` command is technically more correct regardless.

Fixes #22.