### PR TITLE
removes empty release script again

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo -n ""


### PR DESCRIPTION
The existance of this basically no-op/placeholder script breaks deployments with the heroku-gradle-buildpack.


@Frzk FYI: we had to remove that again.